### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Arduino_lib/keywords.txt
+++ b/Arduino_lib/keywords.txt
@@ -21,8 +21,8 @@ lora_send	KEYWORD2
 lora_read	KEYWORD2
 lora_getSnr	KEYWORD2
 lora_getRssi	KEYWORD2
-lora_getFreq KEYWORD2
-lora_getRFConf KEYWORD2
+lora_getFreq	KEYWORD2
+lora_getRFConf	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords